### PR TITLE
Add a headermap reference to build modules with C modules

### DIFF
--- a/Sources/Reloader.swift
+++ b/Sources/Reloader.swift
@@ -15,6 +15,7 @@ public final class Reloader: ObservableObject {
         private let moduleCachePath: URL
         private let confBuildDir: URL
         private let headerSearchPaths: [URL]
+        private let headerMap: URL
         private let buildDir: URL
         private let targetTriple: String
         private let sdk: URL
@@ -36,6 +37,9 @@ public final class Reloader: ObservableObject {
                     .appendingPathComponent("Objects-normal")
                     .appendingPathComponent(arch)
             }
+            self.headerMap = confBuildDir
+                .appendingPathComponent(mainModule + ".build")
+                .appendingPathComponent("\(mainModule)-project-headers.hmap")
             self.buildDir = headerSearchPaths.first!
             self.targetTriple = targetTriple
             self.sdk = sdk
@@ -80,7 +84,8 @@ public final class Reloader: ObservableObject {
                 ["-module-cache-path", moduleCachePath.path], // required in some cases
                 ["-Xlinker", "-undefined", "-Xlinker", "suppress"], // avoid fatal error on the linker
                 ["-Xfrontend", "-disable-access-control"], // with this, internal symbols can be used
-                (headerSearchPaths + importedModuleSearchPaths).flatMap { ["-I", $0.path] }
+                (headerSearchPaths + importedModuleSearchPaths).flatMap { ["-I", $0.path] },
+                ["-Xcc", "-I", "-Xcc", headerMap.path]
             ].flatMap { $0 }
             task.setValue(args, forKey: "arguments")
             NSLog("%@", "🍓 exec and args = ")


### PR DESCRIPTION
some header files may be needed for swiftc to build a swift file that imports a swift module (e.g. it depends on objc with a bridging header, or on a module imported from a c library module). an intermediate header map file may contain all the headers for that.

see also https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html

> Header maps (also known as “header maps”) are files Xcode uses to compile the locations of the headers used in a target. These files use the suffix .hmap. Xcode passes the header maps it puts together to C-based compilers through the -I argument.
