### PR TITLE
Remove unneeded `@State` as a fake hook to force update SwiftUI views

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -11,9 +11,8 @@ import SwiftUI
 struct ContentView: View {
 
 #if DEBUG
-    // these two lines are fake hook to force update of SwiftUI views
+    // this is a fake hook to force update of SwiftUI views
     @ObservedObject private var reloader = App.reloader
-    @State private var requiredDummyState: Void = ()
 #endif
 
     // mark `dynamic` to be replaced runtime


### PR DESCRIPTION
a Swift UI view seems to be updated just as `@ObservedObject` publishes changes