### PR TITLE
Support Vision Pro (vision OS device)

### DIFF
--- a/BuildHelper/Sources/BuildHelper.swift
+++ b/BuildHelper/Sources/BuildHelper.swift
@@ -65,7 +65,7 @@ public final class BuildHelper: ObservableObject {
 
         func setRuntimePeer(_ runtimePeer: RuntimePeer?) {
             var runtimePeer = runtimePeer
-            if let p = runtimePeer?.builderParams {
+            if let p = runtimePeer?.builderParams, p.codesignIdentity == nil {
                 let identity = p.env.estimatedProductBundlePath.filter { FileManager.default.fileExists(atPath: $0.path) }.lazy.compactMap {
                     let stderr = try? NSTaskCommand(launchPath: "/usr/bin/codesign", args: ["-dvvvvv", $0.path]).run().stderr
                     // extract `Apple Development: xxxxxx@xxxxxx (XXXXXXXXXX)`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We can use either Standalone Reloader or Proxy Reloader. Standalone Reloader run
 | macOS app (App Sandbox = YES) | ❌         | ❌ (codesign cannot be trusted to load) |
 | macOS app (Designed for iPad) | ❌         | ❌ (codesign cannot be trusted to load) |
 | visionOS app on Simulator     | ✅         | ✅ |
-| visionOS app on Device        | ?          | ? (codesign with Individual, Company or Enterprise ADP) |
+| visionOS app on Device        | ❌         | ✅ (codesign with Individual, Company or Enterprise ADP) |
 
 
 ## Features

--- a/Sources/Core/Builder.swift
+++ b/Sources/Core/Builder.swift
@@ -145,8 +145,16 @@ public final actor Builder {
 
         NSLog("%@", "🍓 build: exec and args = ")
         print("\(command.launchPath) \(command.args.joined(separator: " "))")
-        
-        try command.run()
+
+        do {
+            try command.run()
+        } catch let error as NSTaskCommand.Error {
+            if case .failureStatus(status: _, stdout: let stdout, stderr: let stderr) = error {
+                if let v = stdout, !v.isEmpty { NSLog("🍓 build stdout:"); print(v) }
+                if let v = stderr, !v.isEmpty { NSLog("🍓 build stderr:"); print(v) }
+            }
+            throw error
+        }
     }
 
     /// codesign the dylib

--- a/Sources/Core/Env.swift
+++ b/Sources/Core/Env.swift
@@ -80,13 +80,19 @@ public struct Env: Codable, Equatable {
     /// arm64-apple-ios14.0-simulator
     /// arm64-apple-macos13.0
     public var estimatedTargetTriple: String? {
-        #if os(iOS)
-        let os = "ios"
-        #elseif os(macOS)
-        let os = "macos"
-        #elseif os(visionOS)
-        let os = "xros"
-        #endif
+        let os = switch DTPlatformName {
+        case "iphoneos", "iphonesimulator": "ios"
+        case "macos": "macos"
+        case "xros", "xrsimulator": "xros"
+        default:
+#if os(iOS)
+            "ios"
+#elseif os(macOS)
+            "macos"
+#elseif os(visionOS)
+            "xros"
+#endif
+        }
         let isSimulator = DTPlatformName?.contains("simulator") == true
         return [estimatedArch, "apple", os + estimatedDeploymentOSVersion!, isSimulator ? "simulator" : nil]
             .compactMap { $0 }.joined(separator: "-")

--- a/Sources/ProxyReloader/Proxy.swift
+++ b/Sources/ProxyReloader/Proxy.swift
@@ -124,12 +124,14 @@ final actor Proxy {
             self.session = nil
         case .connecting: break
         case .connected:
-            do {
-                NSLog("%@", "🍓 \(#function) connected: sending builderParams = \(builderParams)")
-                let payload = try JSONEncoder().encode(builderParams)
-                try self.session?.send(payload, toPeers: [peerID], with: .reliable)
-            } catch {
-                NSLog("%@", "🍓 \(#function) error = \(error)")
+            Task.detached { @MainActor in
+                do {
+                    NSLog("%@", "🍓 \(#function) connected: sending builderParams = \(self.builderParams)")
+                    let payload = try JSONEncoder().encode(self.builderParams)
+                    try await self.session?.send(payload, toPeers: [peerID], with: .reliable)
+                } catch {
+                    NSLog("%@", "🍓 \(#function) error = \(error)")
+                }
             }
         @unknown default: break
         }

--- a/Sources/ProxyReloader/ProxyReloader.swift
+++ b/Sources/ProxyReloader/ProxyReloader.swift
@@ -8,6 +8,7 @@ public final class ProxyReloader: ObservableObject {
     @Published public private(set) var dateReloaded: Date?
 
     public init(_ builderParams: Builder.InputParameters) {
+        print(Env.shared)
         self.proxy = Proxy(builderParams: builderParams, shouldConnectToBuilder: UserConsent.alert)
 
         Task {


### PR DESCRIPTION
visionOS 1.0 device env cannot reveal build products dir.
As far as I digged, parameters enough to estimate build products dir is only embedded in LC_RPATH of the executable.
read dyld info and use the data to estimate build params for BuildHelper.